### PR TITLE
Add a name attribute to the cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "opsworks_delayed_job"
 maintainer       "Artsy"
 maintainer_email "it@artsymail.com"
 license          "MIT"


### PR DESCRIPTION
berkshelf Had some things to say about not having a name in the metadata.rb, so this adds one.
