### PR TITLE
Fixing default delayed_job binary location 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,19 +11,19 @@ else
 end
 
 node[:deploy].each do |application, deploy|
-  
+
   default[:delayed_job][application] = {}
-  default[:delayed_job][application][:path_to_script] = node[:delayed_job][:path_to_script] || 'script'
+  default[:delayed_job][application][:path_to_script] = node[:delayed_job][:path_to_script] || 'bin'
   default[:delayed_job][application][:pools] = {}
-  
+
   # Default to node[:delayed_job][:pool_size] workers, each with empty ({}) config.
   default[:delayed_job][application][:pools][:default] = Hash[node[:delayed_job][:pool_size].times.map{|i| [i.to_s, {}] }]
-  
+
   # Use node[:delayed_job][application][:pools][HOSTNAME] if provided.
   default[:delayed_job][application][:pool] = node[:delayed_job][application][:pools][node[:opsworks][:instance][:hostname]] || node[:delayed_job][application][:pools][:default]
   Chef::Log.debug("Set delayed_job attributes for #{application} to #{node[:delayed_job][application].to_hash.inspect}")
-  
+
   default[:delayed_job][application][:restart_command] = "sudo monit restart -g delayed_job_#{application}_group"
-  
+
 end
 


### PR DESCRIPTION
`script` folder is from Rails 2, which is pretty damn old and not default anymore.