### PR TITLE
Added environment variables to command in monit configuration file

### DIFF
--- a/templates/default/delayed_job.monitrc.erb
+++ b/templates/default/delayed_job.monitrc.erb
@@ -2,8 +2,8 @@
 <% identifier = "#{@application}-#{key}" %>
 check process delayed_job.<%= identifier %>
   with pidfile <%= @deploy[:deploy_to] %>/shared/pids/delayed_job.<%= identifier %>.pid
-  start program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> bundle exec <%= @delayed_job[:path_to_script] %>/delayed_job start --identifier=<%= identifier %> <%= ("--queues=#{config['queues']}" if config['queues']) %> <%= ("--sleep-delay=#{config['sleep_delay']}" if config['sleep_delay']) %>'"
-  stop  program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> bundle exec <%= @delayed_job[:path_to_script] %>/delayed_job stop --identifier=<%= identifier %>'"
+  start program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> <%= OpsWorks::Escape.escape_double_quotes(@deploy[:environment_variables]).map { |k,v| "#{k}=\"#{v}\"" }.join(" ") %> bundle exec <%= @delayed_job[:path_to_script] %>/delayed_job start --identifier=<%= identifier %> <%= ("--queues=#{config['queues']}" if config['queues']) %> <%= ("--sleep-delay=#{config['sleep_delay']}" if config['sleep_delay']) %>'"
+  stop  program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> <%= OpsWorks::Escape.escape_double_quotes(@deploy[:environment_variables]).map { |k,v| "#{k}=\"#{v}\"" }.join(" ") %> bundle exec <%= @delayed_job[:path_to_script] %>/delayed_job stop --identifier=<%= identifier %>'"
   group delayed_job_<%= @application %>_group
 
 <% end %>


### PR DESCRIPTION
Some rails application depend on environment variables being present to
perform different operations. This environment variables are often
API keys, SMTP configuration, or even database configuration. This pull 
request adds the environment variables provided in the opsworks app
configuration to the command that runs the delayed_job script